### PR TITLE
Update reference to gomock

### DIFF
--- a/lib/go/test/Makefile.am
+++ b/lib/go/test/Makefile.am
@@ -42,7 +42,7 @@ gopath: $(top_srcdir)/compiler/cpp/thrift $(THRIFTTEST) \
 	$(THRIFT) GoTagTest.thrift
 	$(THRIFT) TypedefFieldTest.thrift
 	$(THRIFT) RefAnnotationFieldsTest.thrift
-	GOPATH=`pwd`/gopath $(GO) get code.google.com/p/gomock/gomock
+	GOPATH=`pwd`/gopath $(GO) get github.com/golang/mock/gomock
 	ln -nfs ../../../thrift gopath/src/thrift
 	ln -nfs ../../tests gopath/src/tests
 	touch gopath

--- a/lib/go/test/tests/optional_fields_test.go
+++ b/lib/go/test/tests/optional_fields_test.go
@@ -21,7 +21,7 @@ package tests
 
 import (
 	"bytes"
-	gomock "code.google.com/p/gomock/gomock"
+	gomock "github.com/golang/mock/gomock"
 	"optionalfieldstest"
 	"testing"
 	"thrift"

--- a/lib/go/test/tests/protocol_mock.go
+++ b/lib/go/test/tests/protocol_mock.go
@@ -23,8 +23,8 @@
 package tests
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	thrift "thrift"
-	gomock "code.google.com/p/gomock/gomock"
 )
 
 // Mock of TProtocol interface

--- a/test/go/Makefile.am
+++ b/test/go/Makefile.am
@@ -32,7 +32,7 @@ gopath: $(THRIFT) ThriftTest.thrift
 	$(THRIFTCMD) ThriftTest.thrift
 	$(THRIFTCMD) ../StressTest.thrift
 	ln -nfs ../../../lib/go/thrift src/thrift
-	GOPATH=`pwd` $(GO) get code.google.com/p/gomock/gomock
+	GOPATH=`pwd` $(GO) get github.com/golang/mock/gomock
 	touch gopath
 
 bin/testclient: gopath
@@ -51,7 +51,7 @@ check: gopath
 	GOPATH=`pwd` $(GO) test -v common/...
 
 genmock: gopath
-	GOPATH=`pwd` $(GO) install code.google.com/p/gomock/mockgen
+	GOPATH=`pwd` $(GO) install github.com/golang/mock/gomock
 	GOPATH=`pwd` bin/mockgen -destination=src/common/mock_handler.go -package=common gen/thrifttest ThriftTest
 
 EXTRA_DIST = \

--- a/test/go/src/common/clientserver_test.go
+++ b/test/go/src/common/clientserver_test.go
@@ -20,9 +20,9 @@
 package common
 
 import (
-	"code.google.com/p/gomock/gomock"
 	"errors"
 	"gen/thrifttest"
+	"github.com/golang/mock/gomock"
 	"reflect"
 	"testing"
 	"thrift"

--- a/test/go/src/common/mock_handler.go
+++ b/test/go/src/common/mock_handler.go
@@ -23,8 +23,8 @@
 package common
 
 import (
-	gomock "code.google.com/p/gomock/gomock"
 	thrifttest "gen/thrifttest"
+	gomock "github.com/golang/mock/gomock"
 )
 
 // Mock of ThriftTest interface


### PR DESCRIPTION
code.google.com doesn't exist anymore, so this will update the reference to
github.com.

No need to merge this, let's have this as a reference. This is fixed in HEAD
in the apache repo if I'm not mistaken.
