### PR TITLE
Empty Ruby read buffer on transport open

### DIFF
--- a/lib/rb/lib/thrift/transport/framed_transport.rb
+++ b/lib/rb/lib/thrift/transport/framed_transport.rb
@@ -34,6 +34,10 @@ module Thrift
     end
 
     def open
+      # Empty the read buffer when we open the transport to make sure that we
+      # don't have data in the buffer.
+      @rbuf = Bytes.empty_byte_buffer
+
       @transport.open
     end
 


### PR DESCRIPTION
This empties the read buffer when the transport is opened in the framed
transport for Ruby.

The commit should fix that when an error occurred (for instance when no fields
are set in a union) we got data in the buffer in the subsequent requests. This
ended up corrupting all requests after the failed one.

Thanks!
